### PR TITLE
feat: hex() and bin() arrived

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "zirc-bench"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "chrono",
  "clap",
@@ -874,14 +874,14 @@ dependencies = [
 
 [[package]]
 name = "zirc-bytecode"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-syntax",
 ]
 
 [[package]]
 name = "zirc-cli"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "assert_cmd",
  "owo-colors",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "zirc-compiler"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-bytecode",
  "zirc-syntax",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "zirc-fmt"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-lexer",
  "zirc-parser",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "zirc-interpreter"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-lexer",
  "zirc-parser",
@@ -926,14 +926,14 @@ dependencies = [
 
 [[package]]
 name = "zirc-lexer"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-syntax",
 ]
 
 [[package]]
 name = "zirc-parser"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-lexer",
  "zirc-syntax",
@@ -941,11 +941,11 @@ dependencies = [
 
 [[package]]
 name = "zirc-syntax"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 
 [[package]]
 name = "zirc-vm"
-version = "0.0.1-dev"
+version = "0.0.2-dev"
 dependencies = [
  "zirc-bytecode",
  "zirc-syntax",

--- a/crates/zirc-bytecode/src/builtin.rs
+++ b/crates/zirc-bytecode/src/builtin.rs
@@ -17,6 +17,8 @@ pub enum Builtin {
     Max,
     Pow,
     Sqrt,
+    Hex,
+    Bin,
     // String functions
     Upper,
     Lower,

--- a/crates/zirc-compiler/src/compiler.rs
+++ b/crates/zirc-compiler/src/compiler.rs
@@ -81,6 +81,9 @@ pub(crate) fn builtin_of(name: &str) -> Option<zirc_bytecode::Builtin> {
         "max" => Some(zirc_bytecode::Builtin::Max),
         "pow" => Some(zirc_bytecode::Builtin::Pow),
         "sqrt" => Some(zirc_bytecode::Builtin::Sqrt),
+        // TODO: check if hex/bin need special handling here or move separately
+        "bin" => Some(zirc_bytecode::Builtin::Bin),
+        "hex" => Some(zirc_bytecode::Builtin::Hex),
         // String functions
         "upper" => Some(zirc_bytecode::Builtin::Upper),
         "lower" => Some(zirc_bytecode::Builtin::Lower),

--- a/crates/zirc-interpreter/src/interpreter.rs
+++ b/crates/zirc-interpreter/src/interpreter.rs
@@ -238,6 +238,8 @@ impl Interpreter {
                     "max" => return self.call_max(env, args),
                     "pow" => return self.call_pow(env, args),
                     "sqrt" => return self.call_sqrt(env, args),
+                    "hex" => return self.call_hex(env, args),
+                    "bin" => return self.call_bin(env, args),
                     // String functions
                     "upper" => return self.call_upper(env, args),
                     "lower" => return self.call_lower(env, args),
@@ -559,6 +561,36 @@ impl Interpreter {
                 Ok(Value::Int(result))
             },
             other => error(format!("sqrt() expects int, got {:?}", other)),
+        }
+    }
+
+    /// Hexadecimal function converts integer to hex string
+    fn call_hex(&mut self, env: &mut Env<'_>, args: &[Expr]) -> Result<Value> {
+        if args.len() != 1 { return error("hex() expects exactly 1 argument"); }
+        let val = self.eval_expr(env, &args[0])?;
+        match val {
+            Value::Int(n) => {
+                let result = format!("0x{:x}", n);
+                self.mem.strings_allocated += 1;
+                self.mem.bytes_allocated += result.len();
+                Ok(Value::Str(result))
+            },
+            other => error(format!("hex() expects int, got {:?}", other)),
+        }
+    }
+
+    /// Binary function converts integer to binary string
+    fn call_bin(&mut self, env: &mut Env<'_>, args: &[Expr]) -> Result<Value> {
+        if args.len() != 1 { return error("bin() expects exactly 1 argument"); }
+        let val = self.eval_expr(env, &args[0])?;
+        match val {
+            Value::Int(n) => {
+                let result = format!("0b{:b}", n);
+                self.mem.strings_allocated += 1;
+                self.mem.bytes_allocated += result.len();
+                Ok(Value::Str(result))
+            },
+            other => error(format!("bin() expects int, got {:?}", other)),
         }
     }
     

--- a/crates/zirc-vm/src/vm.rs
+++ b/crates/zirc-vm/src/vm.rs
@@ -647,6 +647,20 @@ impl Vm {
                                 other => return error(format!("sqrt() expects int, got {:?}", other)),
                             }
                         }
+                        Builtin::Hex => {
+                            if args.len() != 1 { return error("hex() expects exactly 1 argument"); }
+                            match &args[0] {
+                                Value::Int(n) => self.stack.push(Value::Str(format!("{:x}", n))),
+                                other => return error(format!("hex() expects int, got {:?}", other)),
+                            }
+                        }
+                        Builtin::Bin => {
+                            if args.len() != 1 { return error("bin() expects exactly 1 argument"); }
+                            match &args[0] {
+                                Value::Int(n) => self.stack.push(Value::Str(format!("{:b}", n))),
+                                other => return error(format!("bin() expects int, got {:?}", other)),
+                            }
+                        }
                         // String functions
                         Builtin::Upper => {
                             if args.len() != 1 { return error("upper() expects exactly 1 argument"); }


### PR DESCRIPTION
### Overview
- Added two new methods in builtins: `hex(n)` and `bin(n)`
> **NOTE**: By now this two methods only supports **integer or numbers** convertions.

<img width="691" height="227" alt="image" src="https://github.com/user-attachments/assets/1df34f9a-b2e2-4ebc-b50e-9da916ae4ede" />
